### PR TITLE
fix: trust proxy and production start script

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,7 @@ const allowedOrigins = [
     process.env.CLIENT_URL,
 ].filter(Boolean);
 
+app.set('trust proxy', 1);
 app.use(cors({ origin: allowedOrigins }));
 app.use(express.json());
 app.use('/uploads', express.static('uploads'));

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon index.js",
-    "start": "nodemon index.js"
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- Add `app.set('trust proxy', 1)` so express-rate-limit doesn't throw a `ValidationError` when Railway's proxy sets `X-Forwarded-For` (this was causing the 502)
- Change `start` script from `nodemon` to `node` for production

🤖 Generated with [Claude Code](https://claude.ai/claude-code)