### PR TITLE
fix: use createRequire to import CJS pdf-parse in ESM

### DIFF
--- a/server/routes/generate.js
+++ b/server/routes/generate.js
@@ -2,7 +2,9 @@ import express from 'express';
 import multer from 'multer';
 import Anthropic from '@anthropic-ai/sdk';
 import mammoth from 'mammoth';
-import pdfParse from 'pdf-parse';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const pdfParse = require('pdf-parse');
 import { pool } from '../db.js';
 import { authenticate } from '../middleware/auth.js';
 


### PR DESCRIPTION
## Summary
- `pdf-parse` is CommonJS-only and has no default export in ESM
- Use `createRequire` to load it as a CJS module from the ESM server

🤖 Generated with [Claude Code](https://claude.ai/claude-code)